### PR TITLE
remove overflow:hidden to create scrollbars

### DIFF
--- a/src/script/modules/settings-menu/components/Modal.module.css
+++ b/src/script/modules/settings-menu/components/Modal.module.css
@@ -34,7 +34,6 @@
 }
 
 .modalContent {
-  overflow: hidden;
   border-radius: 12px;
 }
 


### PR DESCRIPTION
Solves #223 

Does make the modal slightly smaller on large screens, but it means that it can be scrolled through on smaller screens.

![image](https://github.com/dclstn/better-snapchat/assets/74068072/1ed32797-e44f-4aa1-94b8-cf0f29b72374)
